### PR TITLE
Update README.md with another autospawn reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,11 @@ sudo sed -i 's/.*autospawn.*/autospawn = no/g' /etc/pulse/client.conf
 
 sudo sed -i 's/.*autospawn.*/autospawn = no/g' /etc/pulse/client.conf.d/00-enable-autospawn.conf       
 
-# Also If `/etc/xdg/autostart/pulseaudio.desktp` file exist, you have to backup this file to somewhere or have to delete it.
+# Few others Ubuntu flavored distributions may have autospawn defined at some different places, check /etc/init.d/pulseaudio-enable-autospawn
+
+sudo update-rc.d pulseaudio-enable-autospawn remove
+
+# Also If `/etc/xdg/autostart/pulseaudio.desktop` file exist, you have to backup this file to somewhere or have to delete it.
 
 # And finally issue        
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ sudo sed -i 's/.*autospawn.*/autospawn = no/g' /etc/pulse/client.conf.d/00-enabl
 
 # Few others Ubuntu flavored distributions may have autospawn defined at some different places, check /etc/init.d/pulseaudio-enable-autospawn
 
-sudo update-rc.d pulseaudio-enable-autospawn remove
+sudo update-rc.d pulseaudio-enable-autospawn disable
 
 # Also If `/etc/xdg/autostart/pulseaudio.desktop` file exist, you have to backup this file to somewhere or have to delete it.
 


### PR DESCRIPTION
Add reference to pulseaudio-enable-autospawn init script which I have in Linux Mint

```bash
#!/bin/sh
### BEGIN INIT INFO
# Provides: pulseaudio-enable-autospawn
# Required-Start: $local_fs
# Required-Stop: umountfs
# Default-Start: 2 3 4 5
# Default-Stop: 0 1 6
# Short-Description: Enable pulseaudio autospawn
# Description: Enables autospawn for the pulseaudio daemon
### END INIT INFO


set -e

. /lib/lsb/init-functions


case "$1" in
        start|reload|restart|force-reload)
                echo "autospawn=yes" > /run/pulseaudio-enable-autospawn
        ;;
        stop|status)
        ;;
esac
```